### PR TITLE
Handles tests in any test source set

### DIFF
--- a/src/main/groovy/com/github/ksoichiro/console/reporter/ReportTestTask.groovy
+++ b/src/main/groovy/com/github/ksoichiro/console/reporter/ReportTestTask.groovy
@@ -20,7 +20,7 @@ class ReportTestTask extends DefaultTask {
             if (extension.junit.reportOnFailure) {
                 project.gradle.taskGraph.afterTask { Task task, TaskState state ->
                     if (task instanceof Test && state.failure) {
-                        execute()
+                        reportJUnit([task] as Set<Test>)
                     }
                 }
             }
@@ -30,12 +30,12 @@ class ReportTestTask extends DefaultTask {
     @TaskAction
     void exec() {
         if (extension.junit.enabled) {
-            reportJUnit()
+            reportJUnit(project.getTasks().findAll{ t -> t instanceof Test} as Set<Test>)
         }
     }
 
-    void reportJUnit() {
-        JUnitReport report = new JUnitReportParser().parse(project, extension.junit)
+    void reportJUnit(Set<Test> testTask) {
+        JUnitReport report = new JUnitReportParser(testTask).parse(project, extension.junit)
         new JUnitReportWriter().write(project, report, extension.junit)
     }
 }


### PR DESCRIPTION
We are using the [TestSets](https://github.com/unbroken-dome/gradle-testsets-plugin) plugin in our project (to separate integration tests) and the console reporter wasn't working with our new test sets...
I've identified this as the plugin assuming the test output directory and this PR aims at fixing this by resolving the directory based on the task that was just run.

Note that when automagically attached to the task we report only on that task. When running `gradle reportTest` however we scan for all tests tasks and report on all of them (when there is anything to report).

Thanks for looking into the PR.
