### PR TITLE
Update ConsoleReporterExtension to Internal

### DIFF
--- a/src/main/groovy/com/github/ksoichiro/console/reporter/ReportCoverageTask.groovy
+++ b/src/main/groovy/com/github/ksoichiro/console/reporter/ReportCoverageTask.groovy
@@ -5,10 +5,12 @@ import com.github.ksoichiro.console.reporter.parser.JacocoReportParser
 import com.github.ksoichiro.console.reporter.writer.CoberturaReportWriter
 import com.github.ksoichiro.console.reporter.writer.JacocoReportWriter
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 class ReportCoverageTask extends DefaultTask {
     public static String NAME = 'reportCoverage'
+    @Internal
     ConsoleReporterExtension extension
 
     ReportCoverageTask() {


### PR DESCRIPTION
The current ReportCoverageTask does not support
Gradle 7.x due to properties without annotations.

The ConsoleReporterExtension is set to Internal
because it is not an input nor an output directory.

Reference:
  - https://docs.gradle.org/current/userguide/validation_problems.html#missing_annotation

Resolves:
  - https://github.com/ksoichiro/gradle-console-reporter/issues/15